### PR TITLE
Add getChunk function to access the rest of the current chunk

### DIFF
--- a/Data/Attoparsec/ByteString.hs
+++ b/Data/Attoparsec/ByteString.hs
@@ -67,6 +67,7 @@ module Data.Attoparsec.ByteString
     , I.takeWhile
     , I.takeWhile1
     , I.takeTill
+    , I.getChunk
 
     -- ** Consume all remaining input
     , I.takeByteString

--- a/Data/Attoparsec/ByteString/Internal.hs
+++ b/Data/Attoparsec/ByteString/Internal.hs
@@ -54,6 +54,7 @@ module Data.Attoparsec.ByteString.Internal
     , takeWhile
     , takeWhile1
     , takeTill
+    , getChunk
 
     -- ** Consume all remaining input
     , takeByteString
@@ -295,6 +296,17 @@ takeByteString = B.concat `fmap` takeRest
 -- | Consume all remaining input and return it as a single string.
 takeLazyByteString :: Parser L.ByteString
 takeLazyByteString = L.fromChunks `fmap` takeRest
+
+-- | Return the rest of the current chunk without consuming anything
+--
+-- If the current chunk is empty, then ask for more input.
+-- If the is no more input, then return Nothing
+getChunk :: Parser (Maybe ByteString)
+getChunk = do
+  input <- wantInput
+  if input
+    then Just <$> get
+    else return Nothing
 
 data T s = T {-# UNPACK #-} !Int s
 

--- a/tests/QC/ByteString.hs
+++ b/tests/QC/ByteString.hs
@@ -131,6 +131,19 @@ takeTill w s =
 takeWhile1_empty :: Property
 takeWhile1_empty = parseBS (P.takeWhile1 undefined) L.empty === Nothing
 
+getChunk :: L.ByteString -> Property
+getChunk s =
+  maybe (property False) (=== L.toChunks s) $
+    parseBS getChunks s
+  where getChunks = go []
+        go res = do
+          mchunk <- P.getChunk
+          case mchunk of
+            Nothing -> return (reverse res)
+            Just chunk -> do
+              _ <- P.take (B.length chunk)
+              go (chunk:res)
+
 endOfInput :: L.ByteString -> Property
 endOfInput s = parseBS P.endOfInput s === if L.null s
                                           then Just ()
@@ -181,6 +194,7 @@ tests = [
     , testProperty "takeWhile" takeWhile
     , testProperty "takeWhile1" takeWhile1
     , testProperty "takeWhile1_empty" takeWhile1_empty
+    , testProperty "getChunk" getChunk
     , testProperty "word8" word8
     , testProperty "members" members
     , testProperty "nonmembers" nonmembers


### PR DESCRIPTION
The `getChunk` function returns the rest of the current chunk without consuming it.

# Motivation

Often part of the parser is implemented without backtracking, in that case it could be beneficial to implement this particular part in a specialized non-backtracking parser and embed it into the top level backtracking parser. The `getChunk` allows one to do that.

The [scanner](http://hackage.haskell.org/package/scanner) package already can embed attoparsec parser into scanner using [atto](http://hackage.haskell.org/package/scanner-attoparsec-0.1/docs/Scanner-Attoparsec.html). Now I want to do the opposite thing, namely I want to embed scanner into attoparsec. [Here](https://github.com/Yuras/scanner-attoparsec/commit/f7fff690f2e565d94005c26320bcb742d4efc22b) is the prototype.