### PR TITLE
Fix lazy `parseOnly` documentation

### DIFF
--- a/Data/Attoparsec/ByteString/Lazy.hs
+++ b/Data/Attoparsec/ByteString/Lazy.hs
@@ -110,7 +110,7 @@ eitherResult (Done _ r)        = Right r
 eitherResult (Fail _ [] msg)   = Left msg
 eitherResult (Fail _ ctxs msg) = Left (intercalate " > " ctxs ++ ": " ++ msg)
 
--- | Run a parser that cannot be resupplied via a 'T.Partial' result.
+-- | Run a parser and convert its 'Result' to an 'Either' value.
 --
 -- This function does not force a parser to consume all of its input.
 -- Instead, any residual input will be discarded.  To force a parser

--- a/Data/Attoparsec/Text/Lazy.hs
+++ b/Data/Attoparsec/Text/Lazy.hs
@@ -101,7 +101,7 @@ eitherResult (Done _ r)        = Right r
 eitherResult (Fail _ [] msg)   = Left msg
 eitherResult (Fail _ ctxs msg) = Left (intercalate " > " ctxs ++ ": " ++ msg)
 
--- | Run a parser that cannot be resupplied via a 'T.Partial' result.
+-- | Run a parser and convert its 'Result' to an 'Either' value.
 --
 -- This function does not force a parser to consume all of its input.
 -- Instead, any residual input will be discarded.  To force a parser


### PR DESCRIPTION
This pull request addresses an oversight of mine in #175: the `Result` type for lazy input has no `Partial` constructor. There can be leftover input, however, so the rest of the documentation is correct.