### PR TITLE
Support ghc-prim-0.8 and GHC 9.2

### DIFF
--- a/Data/Attoparsec/ByteString/FastSet.hs
+++ b/Data/Attoparsec/ByteString/FastSet.hs
@@ -32,10 +32,10 @@ module Data.Attoparsec.ByteString.FastSet
     , charClass
     ) where
 
-import Data.Bits ((.&.), (.|.))
+import Data.Bits ((.&.), (.|.), unsafeShiftL)
 import Foreign.Storable (peekByteOff, pokeByteOff)
-import GHC.Exts (Int(I#), iShiftRA#, narrow8Word#, shiftL#)
-import GHC.Word (Word8(W8#))
+import GHC.Exts (Int(I#), iShiftRA#)
+import GHC.Word (Word8)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Internal as I
@@ -67,11 +67,8 @@ data I = I {-# UNPACK #-} !Int {-# UNPACK #-} !Word8
 shiftR :: Int -> Int -> Int
 shiftR (I# x#) (I# i#) = I# (x# `iShiftRA#` i#)
 
-shiftL :: Word8 -> Int -> Word8
-shiftL (W8# x#) (I# i#) = W8# (narrow8Word# (x# `shiftL#` i#))
-
 index :: Int -> I
-index i = I (i `shiftR` 3) (1 `shiftL` (i .&. 7))
+index i = I (i `shiftR` 3) (1 `unsafeShiftL` (i .&. 7))
 {-# INLINE index #-}
 
 -- | Check the set for membership.

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -46,7 +46,7 @@ library
                  scientific >= 0.3.1 && < 0.4,
                  transformers >= 0.2 && (< 0.4 || >= 0.4.1.0) && < 0.6,
                  text >= 1.1.1.3,
-                 ghc-prim <0.8
+                 ghc-prim <0.9
   if impl(ghc < 7.4)
     build-depends:
       bytestring < 0.10.4.0


### PR DESCRIPTION
Tested with 

```cabal
packages: .

tests: True

allow-newer:
  scientific:base,
  integer-logarithms:*,
  splitmix:*
```