### PR TITLE
Drop support of GHC <= 7.2

### DIFF
--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -39,7 +39,7 @@ Flag developer
 
 library
   build-depends: array,
-                 base >= 4.3 && < 5,
+                 base >= 4.5 && < 5,
                  bytestring <0.12,
                  containers,
                  deepseq,


### PR DESCRIPTION
Closes #193.