### PR TITLE
Inlining `memberWord8` and `memberWord8.search` functions

### DIFF
--- a/Data/Attoparsec/ByteString/FastSet.hs
+++ b/Data/Attoparsec/ByteString/FastSet.hs
@@ -77,7 +77,9 @@ memberWord8 w (Table t)  =
     let I byte bit = index (fromIntegral w)
     in  U.unsafeIndex t byte .&. bit /= 0
 memberWord8 w (Sorted s) = search 0 (B.length s - 1)
-    where search lo hi
+    where
+        {-# INLINE search #-} 
+        search lo hi
               | hi < lo = False
               | otherwise =
                   let mid = (lo + hi) `quot` 2
@@ -85,6 +87,7 @@ memberWord8 w (Sorted s) = search 0 (B.length s - 1)
                        GT -> search (mid + 1) hi
                        LT -> search lo (mid - 1)
                        _ -> True
+{-# INLINE memberWord8 #-}
 
 -- | Check the set for membership.  Only works with 8-bit characters:
 -- characters above code point 255 will give wrong answers.


### PR DESCRIPTION
I speak English very bad, so i'm sorry if there are serious grammatical errors.

I was working on an application where parsing was the most expensive part and during profiling I found a memory and cpu leaks on calls of `memberWord8` and `memberWord8.searh` functions.

You can see huge number of entries of this two functions with high individual memory allocation and cpu time percents.
```
...
	total time  =        2.00 secs   (8015 ticks @ 1000 us, 4 processors)
	total alloc = 9,213,435,328 bytes  (excludes profiling overheads)
...
                                                                                                                                                                                                individual      inherited
COST CENTRE                         MODULE                                SRC                                                                                              no.       entries  %time %alloc   %time %alloc
...
     mkParser                       App.Env.Parser                        src/App/Env/Parser.hs:(21,1)-(51,73)                                                             70305           0    6.3    0.0    86.2   81.3
      memberWord8                   Data.Attoparsec.ByteString.FastSet    Data/Attoparsec/ByteString/FastSet.hs:(76,1)-(87,32)                                             70326    62988619   12.4    0.0    30.0   26.5
       memberWord8.search           Data.Attoparsec.ByteString.FastSet    Data/Attoparsec/ByteString/FastSet.hs:(80,11)-(87,32)                                            70334   123937238   17.4   26.5    17.6   26.5
        memberWord8.search.mid      Data.Attoparsec.ByteString.FastSet    Data/Attoparsec/ByteString/FastSet.hs:83:23-46                                                   70335    62868619    0.3    0.0     0.3    0.0
       memberWord8.(...)            Data.Attoparsec.ByteString.FastSet    Data/Attoparsec/ByteString/FastSet.hs:77:9-43                                                    70356      120000    0.0    0.0     0.0    0.0

...
 ```

After inling both of thems, i got 25% perfomance increase as you can see (`total time` and `total alloc`). I produced the same conditions for both of application runs
```
...
	total time  =        1.53 secs   (6112 ticks @ 1000 us, 4 processors)
	total alloc = 6,767,789,280 bytes  (excludes profiling overheads)
...
                                                                                                                                                                                                individual      inherited
COST CENTRE                         MODULE                                SRC                                                                                              no.       entries  %time %alloc   %time %alloc
...
     mkParser                       App.Env.Parser                        src/App/Env/Parser.hs:(21,1)-(51,73)                                                             70315           0    9.7    0.0    82.5   74.5
...
 ```

I have no experience of working with cabal and there is no documentaion of how to build benchmarks fot this project, so I hope you check if there is any benefits in your benchmarks with INLINE versions of these functions.

Waiting for any discussion and would be glad to answer any questions