### PR TITLE
Update github urls in cabal file

### DIFF
--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -9,8 +9,8 @@ stability:       experimental
 tested-with:     GHC == 7.4.2, GHC ==7.6.3, GHC ==7.8.4, GHC ==7.10.3, GHC ==8.0.2, GHC ==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC ==9.0.2, GHC ==9.2.1
 synopsis:        Fast combinator parsing for bytestrings and text
 cabal-version:   2.0
-homepage:        https://github.com/bgamari/attoparsec
-bug-reports:     https://github.com/bgamari/attoparsec/issues
+homepage:        https://github.com/haskell/attoparsec
+bug-reports:     https://github.com/haskell/attoparsec/issues
 build-type:      Simple
 description:
     A fast parser combinator library, aimed particularly at dealing
@@ -194,4 +194,4 @@ benchmark attoparsec-benchmarks
 
 source-repository head
   type:     git
-  location: https://github.com/bgamari/attoparsec
+  location: https://github.com/haskell/attoparsec.git


### PR DESCRIPTION
I'm not sure which repository is the source of truth but `https://github.com/haskell/attoparsec` seems to look right. Also url for git should probably have a `.git` suffix.