### PR TITLE
bump ghc-prim upper bound to <0.10

### DIFF
--- a/Data/Attoparsec/ByteString/Char8.hs
+++ b/Data/Attoparsec/ByteString/Char8.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, CPP, FlexibleInstances, TypeFamilies,
-    TypeSynonymInstances, GADTs #-}
+    TypeOperators, TypeSynonymInstances, GADTs #-}
 #if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-} -- Imports internal modules
 #endif

--- a/Data/Attoparsec/Text/Internal.hs
+++ b/Data/Attoparsec/Text/Internal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns, FlexibleInstances, GADTs, OverloadedStrings,
-    Rank2Types, RecordWildCards, TypeFamilies, TypeSynonymInstances #-}
+    Rank2Types, RecordWildCards, TypeFamilies, TypeOperators, 
+    TypeSynonymInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- |
 -- Module      :  Data.Attoparsec.Text.Internal

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -60,7 +60,7 @@ library
                  scientific >= 0.3.1 && < 0.4,
                  transformers >= 0.2 && (< 0.4 || >= 0.4.1.0) && < 0.7,
                  text >= 1.1.1.3,
-                 ghc-prim <0.9,
+                 ghc-prim <0.10,
                  attoparsec-internal
   if impl(ghc < 7.4)
     build-depends:


### PR DESCRIPTION
This builds with

```
cabal build -w ghc-9.4.1 --allow-newer=scientific:base,scientific:template-haskell,integer-logarithms:base,integer-logarithms:ghc-prim,hashable:base,hashable:ghc-bignum,integer-logarithms:ghc-bignum
```

`TypeOperators` was added to silence `-Wtype-equality-requires-operators`