### PR TITLE
Allow bytestring-0.12 and test it in Haskell CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -14,8 +14,12 @@
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -227,6 +231,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package attoparsec" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          allow-newer: bytestring
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(attoparsec)$/; }' >> cabal.project.local
           cat cabal.project
@@ -268,6 +273,11 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
+      - name: constraint set bytestring-0.12
+        run: |
+          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
+          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
       - name: constraint set text-2
         run: |
           if [ $((HCNUMVER >= 80400 && HCNUMVER < 90400)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text >= 2' --dependencies-only -j2 all ; fi

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -57,7 +57,7 @@ library attoparsec-internal
   hs-source-dirs: internal
   build-depends: array,
                  base >= 4.3 && < 5,
-                 bytestring <0.12,
+                 bytestring <0.13,
                  text >= 1.1.1.3
   if !impl(ghc >= 8.0)
     build-depends: semigroups >=0.16.1 && <0.21
@@ -73,7 +73,7 @@ library attoparsec-internal
 library
   build-depends: array,
                  base >= 4.5 && < 5,
-                 bytestring <0.12,
+                 bytestring <0.13,
                  containers,
                  deepseq,
                  scientific >= 0.3.1 && < 0.4,

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,5 @@
+branches: master
+
 constraint-set text-1
   constraints: text < 2
   ghc: < 8.4
@@ -9,3 +11,27 @@ constraint-set text-2
   ghc: >= 8.4 && < 9.4
   tests: True
   run-tests: True
+
+constraint-set bytestring-0.12
+  -- bytestring-0.12 requires base >=4.9 (GHC 8.0)
+  ghc: >= 8.0
+  constraints: bytestring >= 0.12
+  --
+  -- The following is silently ignored here:
+  --
+  -- raw-project
+  --   allow-newer: bytestring
+  --
+  tests: True
+  run-tests: True
+
+-- The following is meant to be for constraint-set bytestring-0.12 only,
+-- but there is currently no way to enable `allow-newer: bytestring`
+-- just for the constraint set.
+--
+-- Since core library `bytestring` is constrained to `installed`,
+-- it is not harmful to allow newer `bytestring` in the default runs
+-- as well---it will have no effect there.
+--
+raw-project
+  allow-newer: bytestring


### PR DESCRIPTION
Hackage revision: https://hackage.haskell.org/package/attoparsec-0.14.4/revisions/