### PR TITLE
Allow ghc-prim-0.11 (GHC 9.8), adjust CI cover GHCs 7.10 - 9.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/haskell-CI/haskell-ci
+# For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.16.4
+# version: 0.17.20231010
 #
-# REGENDATA ("0.16.4",["github","attoparsec.cabal","--benchmarks-jobs",">=7.8"])
+# REGENDATA ("0.17.20231010",["github","attoparsec.cabal","--benchmarks-jobs",">=7.8"])
 #
 name: Haskell-CI
 on:
@@ -27,19 +27,24 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:focal
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.2
+          - compiler: ghc-9.8.1
             compilerKind: ghc
-            compilerVersion: 9.6.2
+            compilerVersion: 9.8.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.5
+          - compiler: ghc-9.6.3
             compilerKind: ghc
-            compilerVersion: 9.4.5
+            compilerVersion: 9.6.3
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.4.7
+            compilerKind: ghc
+            compilerVersion: 9.4.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -87,21 +92,6 @@ jobs:
             compilerVersion: 7.10.3
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.6.3
-            compilerKind: ghc
-            compilerVersion: 7.6.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.4.2
-            compilerKind: ghc
-            compilerVersion: 7.4.2
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -110,8 +100,9 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -119,8 +110,9 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
@@ -135,10 +127,12 @@ jobs:
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
             echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
             echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
@@ -151,7 +145,7 @@ jobs:
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV" ; else echo "ARG_BENCH=--disable-benchmarks" >> "$GITHUB_ENV" ; fi
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
@@ -204,7 +198,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -231,7 +225,6 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package attoparsec" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
-          allow-newer: bytestring
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(attoparsec)$/; }' >> cabal.project.local
           cat cabal.project
@@ -270,24 +263,6 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
-      - name: prepare for constraint sets
-        run: |
-          rm -f cabal.project.local
-      - name: constraint set bytestring-0.12
-        run: |
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
-      - name: constraint set text-2
-        run: |
-          if [ $((HCNUMVER >= 80400 && HCNUMVER < 90400)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text >= 2' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80400 && HCNUMVER < 90400)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text >= 2' all ; fi
-          if [ $((HCNUMVER >= 80400 && HCNUMVER < 90400)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text >= 2' all ; fi
-      - name: constraint set text-1
-        run: |
-          if [ $((HCNUMVER < 80400)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text < 2' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER < 80400)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text < 2' all ; fi
-          if [ $((HCNUMVER < 80400)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text < 2' all ; fi
       - name: save cache
         uses: actions/cache/save@v3
         if: always()

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -18,8 +18,9 @@ description:
     file formats.
 
 tested-with:
-  GHC == 9.6.2
-  GHC == 9.4.5
+  GHC == 9.8.1
+  GHC == 9.6.3
+  GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
@@ -29,9 +30,9 @@ tested-with:
   GHC == 8.2.2
   GHC == 8.0.2
   GHC == 7.10.3
-  GHC == 7.8.4
-  GHC == 7.6.3
-  GHC == 7.4.2
+  -- GHC == 7.8.4
+  -- GHC == 7.6.3
+  -- GHC == 7.4.2
 
 extra-source-files:
     benchmarks/*.txt
@@ -79,7 +80,7 @@ library
                  scientific >= 0.3.1 && < 0.4,
                  transformers >= 0.2 && (< 0.4 || >= 0.4.1.0) && < 0.7,
                  text >= 1.1.1.3,
-                 ghc-prim < 0.11,
+                 ghc-prim < 0.12,
                  attoparsec-internal
   if impl(ghc < 7.4)
     build-depends:

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,37 +1,37 @@
 branches: master
 
-constraint-set text-1
-  constraints: text < 2
-  ghc: < 8.4
-  tests: True
-  run-tests: True
-
-constraint-set text-2
-  constraints: text >= 2
-  ghc: >= 8.4 && < 9.4
-  tests: True
-  run-tests: True
-
-constraint-set bytestring-0.12
-  -- bytestring-0.12 requires base >=4.9 (GHC 8.0)
-  ghc: >= 8.0
-  constraints: bytestring >= 0.12
-  --
-  -- The following is silently ignored here:
-  --
-  -- raw-project
-  --   allow-newer: bytestring
-  --
-  tests: True
-  run-tests: True
-
--- The following is meant to be for constraint-set bytestring-0.12 only,
--- but there is currently no way to enable `allow-newer: bytestring`
--- just for the constraint set.
+-- constraint-set text-1
+--   constraints: text < 2
+--   ghc: < 8.4
+--   tests: True
+--   run-tests: True
 --
--- Since core library `bytestring` is constrained to `installed`,
--- it is not harmful to allow newer `bytestring` in the default runs
--- as well---it will have no effect there.
+-- constraint-set text-2
+--   constraints: text >= 2
+--   ghc: >= 8.4 && < 9.4
+--   tests: True
+--   run-tests: True
 --
-raw-project
-  allow-newer: bytestring
+-- constraint-set bytestring-0.12
+--   -- bytestring-0.12 requires base >=4.9 (GHC 8.0)
+--   ghc: >= 8.0
+--   constraints: bytestring >= 0.12
+--   --
+--   -- The following is silently ignored here:
+--   --
+--   -- raw-project
+--   --   allow-newer: bytestring
+--   --
+--   tests: True
+--   run-tests: True
+--
+-- -- The following is meant to be for constraint-set bytestring-0.12 only,
+-- -- but there is currently no way to enable `allow-newer: bytestring`
+-- -- just for the constraint set.
+-- --
+-- -- Since core library `bytestring` is constrained to `installed`,
+-- -- it is not harmful to allow newer `bytestring` in the default runs
+-- -- as well---it will have no effect there.
+-- --
+-- raw-project
+--   allow-newer: bytestring


### PR DESCRIPTION
Closes #223.

Published as revision 5: https://hackage.haskell.org/package/attoparsec-0.14.4/revisions/